### PR TITLE
Fix Image in Readme, Use readonly not disabled for input

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ![ShareDrop](https://www.sharedrop.io/images/a2781750.sharedrop.svg)
+# ![ShareDrop](https://www.sharedrop.io/assets/images/sharedrop.svg)
 
 ShareDrop is HTML5 clone of Apple [AirDrop](http://support.apple.com/kb/ht4783) service. It allows you to transfer files directly between devices, without having to upload them to any server first. It uses [WebRTC](http://www.webrtc.org) for secure peer-to-peer file transfer and [Firebase](https://www.firebase.com) for presence management and WebRTC signaling.
 

--- a/app/templates/about-room.hbs
+++ b/app/templates/about-room.hbs
@@ -7,7 +7,7 @@
   </p>
 
   <p>
-    {{room-url value=controller.currentUrl disabled="disabled" style="display: block; margin: auto;"}}
+    {{room-url value=controller.currentUrl readonly="readonly" style="display: block; margin: auto;"}}
   </p>
 
   <p>


### PR DESCRIPTION
Small fixes. 

+ Fix ShareDrop Image in Readme
+ Use readonly not disabled for input - You cannot [use .focus](https://github.com/cowbell/sharedrop/blob/master/app/components/room-url.js#L7) on a `disabled` input however you can on a `readonly` input. 

