### PR TITLE
Add qrcode to *about room* modal

### DIFF
--- a/app/styles/modules/_modules.sass
+++ b/app/styles/modules/_modules.sass
@@ -56,3 +56,11 @@
     51%
         transform: scale(0.5, 0.5)
         opacity: 0
+
+canvas.qr-code
+  display: block
+  margin: 0 auto 1.42em auto
+  border: solid 1px #ccc
+  border-radius: .3em
+  padding: 1em
+  background-color: #fcfcfc

--- a/app/templates/about-room.hbs
+++ b/app/templates/about-room.hbs
@@ -6,6 +6,10 @@
     Copy provided address and send it to the other person.
   </p>
 
+  <div>
+    {{qr-code data=currentUrl light="#fcfcfc"}}
+  </div>
+
   <p>
     {{room-url value=currentUrl readonly="readonly" style="display: block; margin: auto;"}}
   </p>

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "ember-cli-shims": "^1.0.2",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
+    "ember-qrcode": "0.0.4",
     "foreman": "2.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
This pull requests adds a QR code with room URL to the room modal.

This feature was requested [here](https://github.com/cowbell/sharedrop/issues/51).

### Screenshot
![Screenshot](https://i.imgur.com/esrwUzw.png)