### PR TITLE
Replace v1 with v4 UUID

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "lodash": "^4.17.11",
     "morgan": "^1.5.0",
     "newrelic": "^1.36.1",
-    "node-uuid": "~1.4.2",
     "uuid": "^3.3.2"
   },
   "husky": {

--- a/server.js
+++ b/server.js
@@ -16,7 +16,7 @@ const bodyParser = require('body-parser');
 const cookieParser = require('cookie-parser');
 const cookieSession = require('cookie-session');
 const compression = require('compression');
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 const crypto = require('crypto');
 const FirebaseTokenGenerator = require('firebase-token-generator');
 

--- a/server.js
+++ b/server.js
@@ -16,7 +16,7 @@ const bodyParser = require('body-parser');
 const cookieParser = require('cookie-parser');
 const cookieSession = require('cookie-session');
 const compression = require('compression');
-const uuid = require('uuid');
+const uuidv4 = require('uuid/v4');
 const crypto = require('crypto');
 const FirebaseTokenGenerator = require('firebase-token-generator');
 
@@ -87,7 +87,7 @@ app.get('/room', (req, res) => {
 
 app.get('/auth', (req, res) => {
   const ip = req.headers['cf-connecting-ip'] || req.ip;
-  const uid = uuid.v1();
+  const uid = uuidv4();
   const token = firebaseTokenGenerator.createToken(
     { uid, id: uid }, // will be available in Firebase security rules as 'auth'
     { expires: 32503680000 } // 01.01.3000 00:00

--- a/yarn.lock
+++ b/yarn.lock
@@ -7364,11 +7364,6 @@ node-sass@^4.7.2:
     stdout-stream "^1.4.0"
     "true-case-path" "^1.0.2"
 
-node-uuid@~1.4.2:
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.8.tgz#b040eb0923968afabf8d32fb1f17f1167fdab907"
-  integrity sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=
-
 "nopt@2 || 3", nopt@^3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"


### PR DESCRIPTION
I'm a co-author of the [uuid npm module](https://github.com/kelektiv/node-uuid) which is being used in some places within the code base of sharedrop.

I'm currently trying to understand real-world use cases of [time-based UUIDs ("v1 UUIDs")](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_1_(date-time_and_MAC_address)).

I found one occurrence where v1 UUIDs were being used instead of v4 UUIDs and I was wondering if this case really requires the semantically much more complex v1 UUIDs or whether we could live equally well with purely random v4 UUIDs?

I also used the opportunity to replace the deprecated `node-uuid` dependency with `uuid`, the official successor of `node-uuid`.

I'd be really curious to understand the motivation for choosing v1 over v4 UUIDs in the first place, so any feedback on this would be highly appreciated!